### PR TITLE
use map for config and rm unused configs

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -7,25 +7,23 @@
   classrooms = OodAppkit.clusters.map do |cluster|
     [ cluster.id.to_s, cluster.custom_config[:classrooms].to_h ]
   end.to_h.map do |cluster_id, classrooms|
-    classes = classrooms.select do |k,v|
-      k.start_with?('stable_diffusion') && groups.include?(v)
-    end.map do |k,v|
+    classes = classrooms.select do |app_type, class_configs|
+      app_type == 'stable_diffusion'
+    end.map do |_app_type, class_configs|
+      class_configs.map do |name, class_config|
 
-      tokens = k.gsub('stable_diffusion/', '').split('/')
+        {
+          name: name,
+          size: class_config.fetch('size', 1).to_i,
+          time: class_config.fetch('time', 1).to_i,
+          account: class_config.fetch('project', nil),
+          cluster: cluster_id
+        }
 
-      # cluster, size, module_type & clusterfs are not used
-
-      {
-        name: tokens[0].nil? ? 'unknown' : tokens[0],
-        size: tokens[1].nil? ? 1 : tokens[1].to_i,
-        time: tokens[2].nil? ? 1 : tokens[2].to_i,
-        cluster_fs: tokens[3].nil? ? 'pitzer' : tokens[3].to_s,
-        module_type: tokens[4].nil? ? 'default' : tokens[4].to_s,
-        cluster: cluster_id.to_s,
-        account: v,
-      }
-    end.reject do |arr|
-      arr.empty?
+      end.select do |class_config|
+        acct = class_config.fetch(:account, nil)
+        !acct.nil? && groups.include?(acct)
+      end
     end
   end.flatten
 -%>
@@ -39,16 +37,9 @@ form:
   - classroom
   - account
   - time
-  - cluster_fs
-  - module_type
-
 
 attributes:
   account:
-    widget: "hidden_field"
-  cluster_fs:
-    widget: "hidden_field"
-  module_type:
     widget: "hidden_field"
   time:
     widget: "select"
@@ -82,8 +73,6 @@ attributes:
       - [
         "<%= cr[:name].gsub('_', ' ') %>", "<%= cr[:name] %>",
         data-set-account: "<%= cr[:account] %>",
-        data-set-cluster-fs: "<%= cr[:cluster_fs] %>",
-        data-set-module-type: "<%= cr[:module_type] %>",
         data-set-cluster: "<%= cr[:cluster] %>"
         ]
       <%- end %>

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -1,5 +1,17 @@
 <%-
-  # Grab the projects P#####
+  def size_lookup
+    Hash.new(0).tap do |hsh|
+      hsh[:small] = 0
+      hsh[:medium] = 1
+      hsh[:large] = 2
+      hsh[:xlarge] = 3
+    end
+  end
+
+  def size_to_num(size)
+    size_lookup[size.to_sym].to_i
+  end
+
   groups = OodSupport::User.new.groups.sort_by(&:id).tap { |groups|
     groups.unshift(groups.delete(OodSupport::Process.group))
   }.map(&:name).grep(/^P./)
@@ -14,8 +26,8 @@
 
         {
           name: name,
-          size: class_config.fetch('size', 1).to_i,
-          time: class_config.fetch('time', 1).to_i,
+          size: size_to_num(class_config.fetch('size', 'small')),
+          hours: class_config.fetch('hours', 1).to_i,
           account: class_config.fetch('project', nil),
           cluster: cluster_id
         }
@@ -36,12 +48,12 @@ cluster:
 form:
   - classroom
   - account
-  - time
+  - hours
 
 attributes:
   account:
     widget: "hidden_field"
-  time:
+  hours:
     widget: "select"
     options:
       - [
@@ -50,7 +62,7 @@ attributes:
       - [
           "3 hours", "3",
           <%- classrooms.each do |cr| %>
-            <%- unless cr[:time].to_i >= 3 %>
+            <%- unless cr[:hours].to_i >= 3 %>
             data-option-for-classroom-<%= cr[:name].to_s.gsub('_', '-') %>: false,
             <%- end %>
           <%- end %>
@@ -58,7 +70,7 @@ attributes:
       - [
           "6 hours", "6",
           <%- classrooms.each do |cr| %>
-            <%- unless cr[:time].to_i >= 6 %>
+            <%- unless cr[:hours].to_i >= 6 %>
             data-option-for-classroom-<%= cr[:name].to_s.gsub('_', '-') %>: false,
             <%- end %>
           <%- end %>

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -23,7 +23,7 @@ batch_connect:
 script:
   gpus_per_node: 1
   accounting_id: "<%= account %>"
-  wall_time: "<%= time.to_f * 3600 %>"
+  wall_time: "<%= hours.to_f * 3600 %>"
   native:
     container:
       name: "stable-diffusion"


### PR DESCRIPTION

This update is to 
* use a map config instead of parsing a key
* use `hours` instead of `time`
* remove unused configurations like cluster_fs
* use strings for sizes like small instead of integers (even though this app doesn't use sizes yet)